### PR TITLE
Collision patch

### DIFF
--- a/CLVmain.cpp
+++ b/CLVmain.cpp
@@ -123,16 +123,16 @@ int main(int argc, char* argv[])
     } else
     if(argc > 1 && (String) argv[1] == (String) "-trees")
     {
-        String default_paras[26] = {"nuctrees.txt", "0", "0", "Dist", "list", 
+        String default_paras[28] = {"nuctrees.txt", "0", "0", "Dist", "list", "1", "10",
                                     "", "Majority", "Newick", "URF", "Exp", "time",
                                     "Covariance", "CNM", "1", "0", "1", "0", "1", "0", "1", "0", "1", "0", "auto", "Trees", "matrix"};
-        String options[26] =       {"-f", "-w", "-r", "-o", "-bfm", 
+        String options[28] =       {"-f", "-w", "-r", "-o", "-bfm", "-s", "-c",
                                     "-if", "-ct", "-cfm", "-dm", "-am", "-post",
                                     "-t", "-cm", "-lp", "-lps", "-lpe", "-lpiv", "-ln", "-lns", "-lne", "-lniv", "-hf", "-lf", "-lm", "-ft", "-dfm"};
         
         for(int i = 1; i < argc; i++)
         {
-            for(int j = 0; j < 26; j++)
+            for(int j = 0; j < 28; j++)
             {
                 if((String) argv[i] == options[j] && i + 1 < argc && argv[i + 1][0] != '-')
                 {
@@ -143,7 +143,7 @@ int main(int argc, char* argv[])
             }
         }
         map<String, String> paras;
-        for(int i = 0; i < 26; i++)
+        for(int i = 0; i < 28; i++)
         {
             paras[options[i]] = default_paras[i];
         }

--- a/CLVmain.cpp
+++ b/CLVmain.cpp
@@ -486,7 +486,7 @@ void Compute_BipartMatrix(Trees *TreesData, map<String, String> &paras)
         std::ofstream file_collusion;
         file_collusion.open((char *) outname_collusion);
 		start = clock();
-		TreesData->Compute_Hash(file_collusion);
+		TreesData->Compute_Hash(paras);
 		end = clock();
 		std::cout << "Compute Bipartition time(s):\t" << (end - start) / (double) CLOCKS_PER_SEC << '\n';
 

--- a/CLVmain.cpp
+++ b/CLVmain.cpp
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
     } else
     if(argc > 1 && (String) argv[1] == (String) "-trees")
     {
-        String default_paras[28] = {"nuctrees.txt", "0", "0", "Dist", "list", "1", "10",
+        String default_paras[28] = {"nuctrees.txt", "0", "0", "Dist", "list", "1", "1000",
                                     "", "Majority", "Newick", "URF", "Exp", "time",
                                     "Covariance", "CNM", "1", "0", "1", "0", "1", "0", "1", "0", "1", "0", "auto", "Trees", "matrix"};
         String options[28] =       {"-f", "-w", "-r", "-o", "-bfm", "-s", "-c",

--- a/TreeOPE.cpp
+++ b/TreeOPE.cpp
@@ -811,9 +811,7 @@ void TreeOPE::dfs_compute_hash(
                             bool WEIGHTED,
                             unsigned int NUM_Taxa,
                             map<unsigned long long, Array<char> *> &hash2bitstr,
-                            int numofbipartions,
-                            std::ostream& file_collusion,
-                            int &collusion_cnt)
+                            int numofbipartions)
 {
     // If the node is leaf node, just set the place of the taxon name in the bit string to '1'
     // push the bit string into stack
@@ -860,7 +858,7 @@ void TreeOPE::dfs_compute_hash(
         for (int i = 0; i < startNode->Nchildren; ++i)
         {
             dfs_compute_hash(startNode->child[i], lm, vec_hashrf,
-                             treeIdx, numBitstr, m1, m2,WEIGHTED,NUM_Taxa, hash2bitstr, numofbipartions, file_collusion, collusion_cnt);
+                             treeIdx, numBitstr, m1, m2,WEIGHTED,NUM_Taxa, hash2bitstr, numofbipartions);
         }
         // For weighted RF
         float dist = 0.0;

--- a/TreeOPE.cpp
+++ b/TreeOPE.cpp
@@ -919,12 +919,11 @@ void TreeOPE::dfs_compute_hash(
         if(hash2bitstr[startNode->hv2] != NULL)
         {
             if (!(*btpt == *(hash2bitstr[startNode->hv2]))){
-               file_collusion << startNode->hv2 << ' ' << treeIdx << ' ';
-               btpt->printbits(NUM_Taxa, file_collusion);
-               file_collusion << ' ';
-               hash2bitstr[startNode->hv2]->printbits(NUM_Taxa, file_collusion);
-               file_collusion << '\n';
-               collusion_cnt++;
+                std::cout << "Error! Collison in bitstring detected! Below bitstring is dumpped."
+                hash2bitstr[startNode->hv2]->printbits(NUM_Taxa, file_collusion);
+                std::cout << '\n';
+                std::cout << "TreeScaper is terminated. Please try reset random seed with \"-r\" other than 1 or constant scalar \"-c\" larger than 10 to use different hash function.\n";
+                exit(1);
             }
             delete hash2bitstr[startNode->hv2];
             hash2bitstr[startNode->hv2] = btpt;

--- a/TreeOPE.cpp
+++ b/TreeOPE.cpp
@@ -919,8 +919,8 @@ void TreeOPE::dfs_compute_hash(
         if(hash2bitstr[startNode->hv2] != NULL)
         {
             if (!(*btpt == *(hash2bitstr[startNode->hv2]))){
-                std::cout << "Error! Collison in bitstring detected! Below bitstring is dumpped."
-                hash2bitstr[startNode->hv2]->printbits(NUM_Taxa, file_collusion);
+                std::cout << "Error! Collison in bitstring detected! Below bitstring is dumpped.\n";
+                hash2bitstr[startNode->hv2]->printbits(NUM_Taxa, std::cout);
                 std::cout << '\n';
                 std::cout << "TreeScaper is terminated. Please try reset random seed with \"-r\" other than 1 or constant scalar \"-c\" larger than 10 to use different hash function.\n";
                 exit(1);

--- a/TreeOPE.cpp
+++ b/TreeOPE.cpp
@@ -921,8 +921,9 @@ void TreeOPE::dfs_compute_hash(
             if (!(*btpt == *(hash2bitstr[startNode->hv2]))){
                 std::cout << "Error! Collison in bitstring detected! Below bitstring is dumpped.\n";
                 hash2bitstr[startNode->hv2]->printbits(NUM_Taxa, std::cout);
-                std::cout << '\n';
-                std::cout << "TreeScaper is terminated. Please try reset random seed with \"-r\" other than 1 or constant scalar \"-c\" larger than 10 to use different hash function.\n";
+                std::cout << "\nReplaced by the following bitstring:\n";
+                btpt->printbits(NUM_Taxa, std::cout);
+                std::cout << "\nTreeScaper is terminated. Please try to \nreset random seed with \"-r\" other than 1 or \nreset constant scalar \"-c\" larger than 10 to use different hash function.\n";
                 exit(1);
             }
             delete hash2bitstr[startNode->hv2];

--- a/TreeOPE.h
+++ b/TreeOPE.h
@@ -116,9 +116,7 @@ public:
                                 bool WEIGHTED,
                                 unsigned int NUM_Taxa,
                                 map<unsigned long long, Array<char> *> &hash2bitstr,
-                                int numofbipartition,
-                                std::ostream& file_collusion,
-                                int &collusion_cnt);
+                                int numofbipartition);
 
     static void GetTaxaLabels(NEWICKNODE *node, LabelMap &lm);
 

--- a/Trees.cpp
+++ b/Trees.cpp
@@ -1094,8 +1094,8 @@ void Trees::Compute_Hash(std::map<String, String>& paras)
     #define HASHTABLE_FACTOR                       0.2
 
     // the c value of m2 > c*t*n
-    unsigned int C                          = 100 * atoi((String) paras["-c"]);
-    int32 NEWSEED                           = atoi((String) paras["-s"]);
+    unsigned int C                          = 100 * atoi(paras["-c"]);
+    int32 NEWSEED                           = atoi(paras["-s"]);
 
     if(!vec_hashrf._hashtab2.empty())
     {

--- a/Trees.cpp
+++ b/Trees.cpp
@@ -1104,12 +1104,7 @@ void Trees::Compute_Hash(std::map<String, String>& paras)
 
     unsigned long long M1 = 0;
     unsigned long long M2 = 0;
-    if (NEWSEED != 1000)
-    {
-        vec_hashrf.uhashfunc_init(n_trees, leaveslabelsmaps.size(), C, NEWSEED);
-    }
-    else
-        vec_hashrf.uhashfunc_init(n_trees, leaveslabelsmaps.size(), C);
+    vec_hashrf.uhashfunc_init(n_trees, leaveslabelsmaps.size(), C, NEWSEED);
 
     M1 = vec_hashrf._HF.getM1();
     M2 = vec_hashrf._HF.getM2();

--- a/Trees.cpp
+++ b/Trees.cpp
@@ -1087,15 +1087,15 @@ void Trees::Printf(int *idx, int length)
 //# hash value in tree.
 //########################ZD comment########################################
 
-void Trees::Compute_Hash(std::ostream& file_collusion)
+void Trees::Compute_Hash(std::map<String, String>& paras)
 {
     // Set a random number for m1 (= Initial size of hash table)
     // m1 is the closest value to (t*n)+(t*n*HASHTABLE_FACTOR)
     #define HASHTABLE_FACTOR                       0.2
 
     // the c value of m2 > c*t*n
-    unsigned int C                          =1000;
-    int32 NEWSEED                           = 0  ;
+    unsigned int C                          = 100 * atoi((String) paras["-c"]);
+    int32 NEWSEED                           = atoi((String) paras["-s"]);
 
     if(!vec_hashrf._hashtab2.empty())
     {

--- a/Trees.cpp
+++ b/Trees.cpp
@@ -1115,13 +1115,12 @@ void Trees::Compute_Hash(std::map<String, String>& paras)
         hash2bitstr.clear();
     }
 
-    int collusion_cnt = 0;
 
     for (unsigned int treeIdx = 0; treeIdx < n_trees; ++treeIdx)
     {
         unsigned int numBitstr = 0;
         TreeOPE::dfs_compute_hash(treeset[treeIdx]->root, leaveslabelsmaps, vec_hashrf, treeIdx,
-                                  numBitstr, M1, M2, isweighted, leaveslabelsmaps.size(), hash2bitstr, numberofbipartition[treeIdx], file_collusion, collusion_cnt);
+                                  numBitstr, M1, M2, isweighted, leaveslabelsmaps.size(), hash2bitstr, numberofbipartition[treeIdx]);
     }
 
     if (collusion_cnt > 0)

--- a/Trees.cpp
+++ b/Trees.cpp
@@ -1123,9 +1123,6 @@ void Trees::Compute_Hash(std::map<String, String>& paras)
                                   numBitstr, M1, M2, isweighted, leaveslabelsmaps.size(), hash2bitstr, numberofbipartition[treeIdx]);
     }
 
-    if (collusion_cnt > 0)
-        std::cout << "Warning!" << collusion_cnt << "collisions in hv2 detected!\n See instruction in README.txt. See Collusion_post.out file for bitstrings that get tossed out.\n";
-
     /*map<unsigned long long, Array<char> *>::iterator it = hash2bitstr.begin();
     Array<char> *pt = NULL;
     int n_taxa = leaveslabelsmaps.size();

--- a/Trees.h
+++ b/Trees.h
@@ -92,7 +92,7 @@ public:
 
 //    const NEWICKTREE * &operator[](const int idx) const{return treeset[idx];};   // pick the (index + 1)-th element
 
-    void Compute_Hash(std::ostream& file_collusion);
+    void Compute_Hash(std::map<String, String>& paras);
 
     void Compute_Bipart_Matrix();
     void Compute_Bipart_Matrix(std::map<String, String>& paras);

--- a/hashfunc.cc
+++ b/hashfunc.cc
@@ -150,7 +150,7 @@ CHashFunc::UHashfunc_init(
 	//RandomLib::Random rnd(newseed);		// r created with random seed
 	//std::cout << "    Random seed set to " << rnd.SeedString() << std::endl;
 	
-    srand(1);
+    srand(newseed);
 	for (unsigned int i=0; i<_n; ++i) {
 		//_a1[i] = rnd.Integer<unsigned long long>(_m1-1);
 		_a1[i] = rand() % (_m1-1);


### PR DESCRIPTION
This is a patch that handle the silent collision in Bipartition. For larger tree set with a lot of unique bipartitions, the default setting in V1.1.0 may encounter collisions in labeling Bipartitions and lose some of them silently.

This patch includes following features
1. Detection of collisions in labeling Bipartitions. TreeScaper terminates the code if collision is detected.
2. Keyword "-s", 1 by default, enabled for setting random seed that is used for creating the random label for Bipartitions.
3. Keyword "-c", 1000 by default, enabled for setting the range of the random label for Bipartitions. 
This value should be not larger than 10^6. V1.1.0 uses c = 10. 