### PR TITLE
Ensure version generated before compiling CLVTreeScaper2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,16 @@ LFLAG = -std=c++17 -Wall
 
 OBJ = main.o wstring.o Sparse_matrix.o zdarray.o zdtree.o
 
-all: generate_version CLVTreeScaper2
+all: CLVTreeScaper2
 
 .PHONY: generate_version
 generate_version:
 	@./generate_version.sh
+
+# There must be a "recipe" defined for this rule, or make may not detect
+# that version.hpp was updated.
+version.hpp: generate_version
+	@echo Target generate_version run to generate version number.
 
 CLVTreeScaper2 : $(OBJ)
 	$(CC) $(LFLAG) $^ -o $@


### PR DESCRIPTION
This fixes an issue where the version string may not have been updated when appropriate, because the order of the dependencies for target `all` are not guaranteed, and the new header must be generated before the `CLVTreeScaper2` target.