### PR TITLE
Changes for Integration into CloudForest

### DIFF
--- a/CLVmain.cpp
+++ b/CLVmain.cpp
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 
 		map<String, String> paras = read_paras(argc, argv, n_adj_key_option, default_paras, options);
 
-		if (paras["-key"] != (String) "none")
+		if (paras["-adj-key"] != (String) "none")
 		{
 			std::cout << "Reading parameters from " << paras["-adj-key"] << endl;
 			read_paras_from_csv(paras["-adj-key"], paras, true);
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
 
 		map<String, String> paras = read_paras(argc, argv, n_nldr_key_option, default_paras, options);
 
-		if (paras["-key"] != (String) "none")
+		if (paras["-nldr-key"] != (String) "none")
 		{
 			std::cout << "Reading parameters from " << paras["-nldr-key"] << endl;
 			read_paras_from_csv(paras["-nldr-key"], paras, true);
@@ -252,6 +252,22 @@ TreeSetObjects<Container_type> *trees_driver(map<String, String> &paras, Contain
 	treesobj_ptr->print_Bipart2Tree_Matrix(fout, RCVLIST);
 	fout.close();
 	cout << "Sucessfully printed bipartition-to-tree sparse matrix in Bipartition_" << (char *)paras["-post"] << ".out file.\n\n";
+
+	// Print Taxon ID to name map
+	// Size field of header is no longer output, but is not needed by the CloudForest application.
+	String outname_TaxonID("TaxonID");
+	outname_TaxonID.make_stdname(paras);
+	Header_info Header_TaxonID;
+	Header_TaxonID.insert("created", time_stamp());
+	Header_TaxonID.insert("output type", "Taxon ID");
+	Header_TaxonID.insert("format", "taxon id, taxon name");
+	Header_TaxonID.insert("source", paras["-f"]);
+
+	fout.open((char *)outname_TaxonID);
+	fout << Header_TaxonID;
+	treesobj_ptr->print_TaxonID_Map(fout);
+	fout.close();
+	cout << "Sucessfully printed Taxon ID to name map in TaxonID_" << (char *)paras["-post"] << ".out file.\n\n";
 
 	if (paras["-output"] == (String) "Covariance")
 	{

--- a/zdcommunity.cpp
+++ b/zdcommunity.cpp
@@ -169,8 +169,8 @@ void create_resolution(double lp, double ln, int nb_layers, int *sign, double *&
 
 bool community_detection_automatically(SpecMat::LowerTri<PRECISION> &adj, map<String, String> &paras)
 {
-	string highfreq = (char *)paras["-hf"];
-	string lowfreq = (char *)paras["-lf"];
+	string highfreq = (char *)paras["-comm-hf"];
+	string lowfreq = (char *)paras["-comm-lf"];
 	int modelType = 0;
 	if (paras["-modularity-type"] == (String) "CNM")
 		modelType = 3;
@@ -783,8 +783,8 @@ bool community_detection_automatically(SpecMat::LowerTri<PRECISION> &adj, map<St
 
 bool community_detection_manually(SpecMat::LowerTri<PRECISION> &adj, map<String, String> &paras)
 {
-	string highfreq = (char *)paras["-hf"];
-	string lowfreq = (char *)paras["-lf"];
+	string highfreq = (char *)paras["-comm-hf"];
+	string lowfreq = (char *)paras["-comm-lf"];
 	int modelType = 0;
 	if (paras["-modularity-type"] == (String) "CNM")
 		modelType = 3;

--- a/zdtree.cpp
+++ b/zdtree.cpp
@@ -642,6 +642,7 @@ TreeArray::TreeArray(string &tree, TaxonList &taxon_list, Array<int> &active_lev
 
 	weights = nullptr;
 	t2b = nullptr;
+	t2b_upper = nullptr;
 	edges = nullptr;
 	this->leafsize = 0;
 

--- a/zdtreeobj.hpp
+++ b/zdtreeobj.hpp
@@ -1027,6 +1027,13 @@ public:
 		}
 	};
 
+	void print_TaxonID_Map(ostream &fout) {
+		int n = Taxa->Ind2Taxon.get_size();
+		for (int i = 0; i < n; i++) {
+			fout << i << " , " << Taxa->Ind2Taxon[i] << std::endl;
+		}
+	}
+
 	void print_Bipart2Tree_Matrix(ostream &fout, SparseMatrixOutputType smtype) { (*sb2t_mat).print(fout, smtype); };
 
 	void print_Covariance_Matrix(ostream &fout) { (*cov_mat).print(fout); };


### PR DESCRIPTION
- Outputs TaxonID map file, used by CloudForest visualizations.
- Fixes --nldr-key, --adj-key, --comm-hf, --comm-lf flags
- Fixes segfault from uninitialized t2b_upper when running with --same-leaf 1.